### PR TITLE
improve completion for filenames for 'aptly repo add'

### DIFF
--- a/aptly
+++ b/aptly
@@ -239,8 +239,7 @@ _aptly()
                 return 0
               ;;
               1)
-                local files=$(find . -mindepth 1 -maxdepth 1  \( -type d -or -name \*.deb -or -name \*.dsc -or -name \*.udeb \) -exec basename {} \;)
-                COMPREPLY=($(compgen -W "${files}" -- ${cur}))
+                _filedir '@(deb|dsc|udeb)'
                 return 0
               ;;
             esac


### PR DESCRIPTION
The _filedir function comes included with bash-completions and provides more a more robust and standardized way to handle file and directory names.

Btw. love aptly ;)